### PR TITLE
Fix RedHat default basic installation.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,7 +25,7 @@ class rancid (
 
   # set default parameters
 
-  $default_cloginrc_content = '# This file is being maintained by Puppet.\n# DO NOT EDIT\nConsult man page for cloginrc(5) for help.'
+  $default_cloginrc_content = "# This file is being maintained by Puppet.\n# DO NOT EDIT\nConsult man page for cloginrc(5) for help."
 
   case $::osfamily {
     default: {


### PR DESCRIPTION
the fact lsbmajdistrelease is only present when the metapackage redhat-lsb is installed (which is not installed by default on base systems)
