### PR TITLE
Allow the selection of svn as RCS

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,6 +5,7 @@
 class rancid (
   $filterpwds       = 'ALL', # yes, no, all
   $nocommstr        = 'YES', # yes or no
+  $rcs_system       = 'cvs',
   $maxrounds        = '4',
   $oldtime          = '4',
   $locktime         = '4',
@@ -119,6 +120,7 @@ class rancid (
   validate_re($filterpwds, '^(yes|YES|no|NO|all|ALL)$',
     "rancid::filterpwds is <${filterpwds}> which does not match the regex of \'YES\', \'NO\', or \'ALL\'.")
   validate_re($nocommstr, '^(yes|YES|no|NO)$', "rancid::nocommstr is <${nocommstr}> which does not match the regex of \'YES\' or \'NO\'.")
+  validate_re($rcs_system, '^(svn|cvs)$', "rancid::rcs_system is <${rcs_system}> which does not match the supported systems 'cvs' or 'svn'.")
   validate_re($maxrounds, '^[1-9]+(\d)?$', "rancid::maxrounds is ${maxrounds} and must be a number greater than zero.")
   validate_re($oldtime, '^(\d)+$', "rancid::oldtime is ${oldtime} and must match the regex of a number.")
   validate_re($locktime, '^(\d)+$', "rancid::locktime is ${locktime} and must match the regex of a number.")

--- a/templates/rancid.conf.erb
+++ b/templates/rancid.conf.erb
@@ -31,7 +31,7 @@ LOGDIR=<%= @logdir_real %>; export LOGDIR
 # Select which RCS system to use, "cvs" (default) or "svn".  Do not change
 # this after CVSROOT has been created with rancid-cvs.  Changing between these
 # requires manual conversions.
-RCSSYS=cvs; export RCSSYS
+RCSSYS=<%= @rcs_system %>; export RCSSYS
 #
 # if ACLSORT is NO, access-lists will NOT be sorted.
 #ACLSORT=YES; export ACLSORT


### PR DESCRIPTION
Defaults to cvs, to keep compatibility with existing installations. Exposes 'rcs_system' param, validates that it's either 'svn' or 'cvs', and passes it to the templated config file.
