### PR TITLE
Remove Puppet 3.1.0 from travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ rvm:
 
 env:
   matrix:
-    - PUPPET_GEM_VERSION="~> 3.1.0"
     - PUPPET_GEM_VERSION="~> 3.2.0"
     - PUPPET_GEM_VERSION="~> 3.3.0"
     - PUPPET_GEM_VERSION="~> 3.4.0"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ capability to add router entries to your router.db file with Hiera. Also manages
 
 # Compatibility
 
-Compatible with Puppet v3 with Ruby versions 1.8.7, 1.9.3, 2.0.0 and 2.1.0 on the following platforms.
+Compatible with Puppet v3.2 to v3.7 with Ruby versions 1.8.7, 1.9.3, 2.0.0 and 2.1.0 on the following platforms.
 
 * EL 6 (rancid package from [EPEL](https://fedoraproject.org/wiki/EPEL))
 * Ubuntu 12.04 LTS


### PR DESCRIPTION
We now use `show_diff` on a file resource as of #15, which isn't a thing 3.1 supports.