### PR TITLE
Support Puppet >= 4.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ env:
     - PUPPET_GEM_VERSION="~> 4.6.0"
     - PUPPET_GEM_VERSION="~> 4.7.0"
     - PUPPET_GEM_VERSION="~> 4.8.0"
+    - PUPPET_GEM_VERSION="~> 4.9.0"
     - PUPPET_GEM_VERSION="~> 4"
 
 sudo: false
@@ -61,6 +62,16 @@ matrix:
     - rvm: 1.8.7
       env: PUPPET_GEM_VERSION="~> 4.8.0"
     - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.9.0"
+    - rvm: 1.9.3
+      env: PUPPET_GEM_VERSION="~> 4.9.0"
+    - rvm: 2.0.0
+      env: PUPPET_GEM_VERSION="~> 4.9.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4"
+    - rvm: 1.9.3
+      env: PUPPET_GEM_VERSION="~> 4"
+    - rvm: 2.0.0
       env: PUPPET_GEM_VERSION="~> 4"
     - rvm: 2.3.1
       env: PUPPET_GEM_VERSION="~> 3.2.0"


### PR DESCRIPTION
Puppetlabs dropped support for Ruby <= 2.1.0 with Puppet 4.9 therefore it need to be excluded.