### PR TITLE
Add the ability to use any of the vcs supported by rancid

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,24 @@ Whether to show diffs of <tt>~rancid/.cloginrc</tt> during puppet runs.
 
 - *Default*: true
 
+vcs
+---
+Which version control system to use.  Must be one of git, svn, cvs or USE_DEFAULTS.
+
+- *Default*: 'USE_DEFAULTS'
+
+vcsroot
+-------
+Use a different directory than the default for the vcs you've chosen.
+
+- *Default*: 'USE_DEFAULTS'
+
+manage_vcs_packages
+-------------------
+If true, we will ensure that the appropriate packages are installed for the vcs you've chosen.
+
+- *Default*: false
+
 ===
 
 # define rancid::router_db


### PR DESCRIPTION
This commit fills in the commit message and README missed by
a4e4ab2002cc7c34bf4000288ef6a7179d5dbbd4.

Closes #28



PLEASE can this commit be merged as the very next commit after a4e4ab2002cc7c34bf4000288ef6a7179d5dbbd4.  I don't know why the commit message got dropped during development, but I can only apologise, and hope that this commit makes the best of a bad job.